### PR TITLE
Depend on camera_info_manager in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
   <depend>camera_calibration_parsers</depend>
+  <depend>camera_info_manager</depend>
   <depend>launch_ros</depend>
 
   <export>


### PR DESCRIPTION
This dependency is in CMakeLists but not in package.xml so rosdep does not install it otherwise