### PR TITLE
fixed missing target dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(usb_camera_driver
 
 ament_target_dependencies(usb_camera_driver
     "rclcpp"
+    "rclcpp_components"
     "sensor_msgs"
     "std_msgs"
     "cv_bridge"


### PR DESCRIPTION
This just adds a dependency (it is in find package, but not in target dependencies) which it was complaining about when I tried to build it on dashing.